### PR TITLE
Add Support for Button Interactivity

### DIFF
--- a/Example/DockableSample/ContentView.swift
+++ b/Example/DockableSample/ContentView.swift
@@ -10,7 +10,7 @@ import Dockable
 
 struct ContentView: View {
     @StateObject var controller = DockableController()
-    @StateObject var controllerTwo = DockableController()
+    // @StateObject var controllerTwo = DockableController()
     
     var body: some View {
         VStack {
@@ -21,6 +21,7 @@ struct ContentView: View {
                 controller.enabled.toggle()
             }
             
+            /*
             Text("Dockable View (Tap on me!)")
                 .foregroundColor(.red)
                 .fontWeight(.medium)
@@ -32,6 +33,7 @@ struct ContentView: View {
                 .onTapGesture {
                     controllerTwo.enabled.toggle()
                 }
+             */
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .dockable(controller: controller, view: BasicExample(controller: controller))
@@ -48,9 +50,11 @@ struct BasicExample: View {
         Group {
             switch mode {
             case 0:
-                Text("Width: \(controller.pipWidth)")
-                Text("Height: \(controller.pipHeight)")
-                    .foregroundColor(.green)
+                VStack {
+                    Text("Width: \(Int(controller.renderSize.width))")
+                    Text("Height: \(Int(controller.renderSize.height))")
+                }
+                .foregroundColor(.green)
             case 1:
                 Text("Counter: \(counter)")
                     .foregroundColor(.blue)
@@ -62,10 +66,14 @@ struct BasicExample: View {
             }
         }
         .task {
+            controller.isPlayPauseEnabled = false
             await updateMode()
         }
         .task {
             await updateCounter()
+        }
+        .onChange(of: controller.isPlaying) { isPlaying in
+            print("Playback \(isPlaying ? "is playing" : "is not playing")")
         }
     }
     

--- a/Sources/Dockable/DockableController.swift
+++ b/Sources/Dockable/DockableController.swift
@@ -14,13 +14,15 @@ public final class DockableController: NSObject, ObservableObject, AVPictureInPi
                                        AVPictureInPictureSampleBufferPlaybackDelegate {
     
     @Published public var enabled: Bool = false
-    @Published public var pipWidth: Int = 0
-    @Published public var pipHeight: Int = 0
+    @Published public var renderSize: CGSize = .zero
+    @Published public var isPlaying: Bool = true
     
     internal let bufferLayer = AVSampleBufferDisplayLayer()
     private var pipController: AVPictureInPictureController?
     private var rendererSubscriptions = Set<AnyCancellable>()
     private var pipPossibleObservation: NSKeyValueObservation?
+    
+    public var isPlayPauseEnabled = false
     
     override public init() {
         super.init()
@@ -147,12 +149,13 @@ public final class DockableController: NSObject, ObservableObject, AVPictureInPi
     // MARK: - AVPictureInPictureSampleBufferPlaybackDelegate
     
     public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, setPlaying playing: Bool) {
-        // We do not support play/pause
+        if isPlayPauseEnabled {
+            isPlaying = playing
+        }
     }
     
     public func pictureInPictureControllerIsPlaybackPaused(_ pictureInPictureController: AVPictureInPictureController) -> Bool {
-        // We do not support play/pause
-        return false
+        return isPlayPauseEnabled && isPlaying == false
     }
     
     public func pictureInPictureControllerTimeRangeForPlayback(_ pictureInPictureController: AVPictureInPictureController) -> CMTimeRange {
@@ -162,8 +165,7 @@ public final class DockableController: NSObject, ObservableObject, AVPictureInPi
     }
     
     public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, didTransitionToRenderSize newRenderSize: CMVideoDimensions) {
-        self.pipWidth = Int(newRenderSize.width)
-        self.pipHeight = Int(newRenderSize.height)
+        renderSize = .init(width: Int(newRenderSize.width), height: Int(newRenderSize.height))
     }
     
     public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, skipByInterval skipInterval: CMTime) async {

--- a/Sources/Dockable/ViewBuffer.swift
+++ b/Sources/Dockable/ViewBuffer.swift
@@ -71,7 +71,7 @@ extension View {
         // Timing Info
         let now = CMTime(
             seconds: CACurrentMediaTime(),
-            preferredTimescale: 60
+            preferredTimescale: 120
         )
         
         let timingInfo = CMSampleTimingInfo(


### PR DESCRIPTION
Closes #10 

Work in progress, likely to require more structural changes to provide custom modifiers for this.

Ideally the play/pause button would only 'work' (store changes) if a closure is provided.
Likewise the skip buttons should only be active if a closure is provided for those.